### PR TITLE
Add 3-year period option to reports

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,7 @@ services:
       - "./gitbrag:/app/gitbrag"
       - "./docker/www/prestart.sh:/app/prestart.sh"
     ports:
-      - "80:80"
+      - "8080:80"
     environment:
       IS_DEV: true
       RELOAD: true

--- a/docs/dev/web.md
+++ b/docs/dev/web.md
@@ -7,7 +7,7 @@ The GitBrag web interface provides a browser-based way to view GitHub contributi
 - **GitHub OAuth Authentication**: Secure login using GitHub OAuth with minimal permissions
 - **Public Data Only**: Only displays publicly accessible GitHub data
 - **Report Generation**: View pull request contributions by time period
-- **Period Filtering**: Filter reports by 1 year, 2 years, or all time
+- **Period Filtering**: Filter reports by 1 year, 2 years, 3 years, 5 years, or all time
 - **Repository Breakdown**: See contributions organized by repository
 - **Cached Reports**: Reports are cached for performance, with automatic staleness detection
 - **Responsive Design**: Mobile-first design with dark mode support
@@ -203,7 +203,7 @@ Example: `/user/github/TEDIVM` → 301 Redirect → `/user/github/tedivm`
 
 ### Query Parameters
 
-- `/user/github/{username}?period={period}`: Filter by time period (`1_year`, `2_years`, `all_time`)
+- `/user/github/{username}?period={period}`: Filter by time period (`1_year`, `2_years`, `3_years`, `5_years`, `all_time`)
 - `/user/github/{username}?force=true`: Force regenerate report (requires authentication)
 - `/auth/login?return_to={url}`: Redirect to URL after login
 
@@ -250,7 +250,7 @@ Example: `/user/github/TEDIVM` → 301 Redirect → `/user/github/tedivm`
 ### Report Template (`user_report.html`)
 
 - Report header with username and date range
-- Period selector (1 year, 2 years, all time)
+- Period selector (1 year, 2 years, 3 years, 5 years, all time)
 - Summary card with statistics
 - Repository sections with PR tables
 - Cache status indicator

--- a/gitbrag/services/background_tasks.py
+++ b/gitbrag/services/background_tasks.py
@@ -54,7 +54,7 @@ async def schedule_report_generation(
     Args:
         background_tasks: FastAPI BackgroundTasks instance
         username: GitHub username (subject of the report)
-        period: Report period (1_year, 2_years, etc.)
+        period: Report period (1_year, 2_years, 3_years, 5_years, all_time)
         params_hash: Hash of report parameters
         token: GitHub API token for authenticated requests (required)
 

--- a/gitbrag/services/reports.py
+++ b/gitbrag/services/reports.py
@@ -37,7 +37,7 @@ def normalize_period(period: str | None) -> str:
 
     period = period.lower().strip()
     logger.debug(f"Normalizing period: '{period}'")
-    if period in ("1_year", "2_years", "5_years", "all_time"):
+    if period in ("1_year", "2_years", "3_years", "5_years", "all_time"):
         logger.debug(f"Normalized period result: '{period}'")
         return period
 
@@ -60,6 +60,8 @@ def calculate_date_range(period: str) -> tuple[datetime, datetime]:
         since = until - timedelta(days=365)
     elif period == "2_years":
         since = until - timedelta(days=730)
+    elif period == "3_years":
+        since = until - timedelta(days=1095)
     elif period == "5_years":
         since = until - timedelta(days=1825)
     elif period == "all_time":

--- a/gitbrag/templates/home.html
+++ b/gitbrag/templates/home.html
@@ -77,7 +77,7 @@
         <h3 style="font-size: 1.125rem; margin-bottom: 0.5rem; font-family: 'Courier New', monospace;">--since
           &lt;date&gt;</h3>
         <p style="color: var(--text-secondary);">
-          Filter by 1yr, 2yr, 5yr, or all time. Uses GitHub's created date field, not your local git history.
+          Filter by 1yr, 2yr, 3yr, 5yr, or all time. Uses GitHub's created date field, not your local git history.
         </p>
       </div>
       <div>

--- a/gitbrag/templates/user_report.html
+++ b/gitbrag/templates/user_report.html
@@ -65,6 +65,8 @@ request.url.scheme }}://{{ request.url.netloc }}/static/images/og-image.png{% en
       Past year
       {% elif period == "2_years" %}
       Past 2 years
+      {% elif period == "3_years" %}
+      Past 3 years
       {% elif period == "5_years" %}
       Past 5 years
       {% elif period == "all_time" %}
@@ -80,6 +82,8 @@ request.url.scheme }}://{{ request.url.netloc }}/static/images/og-image.png{% en
       class="period-link {% if period == '1_year' %}active{% endif %}">1 Year</a>
     <a href="/user/github/{{ username }}?period=2_years"
       class="period-link {% if period == '2_years' %}active{% endif %}">2 Years</a>
+    <a href="/user/github/{{ username }}?period=3_years"
+      class="period-link {% if period == '3_years' %}active{% endif %}">3 Years</a>
     <a href="/user/github/{{ username }}?period=5_years"
       class="period-link {% if period == '5_years' %}active{% endif %}">5 Years</a>
     <a href="/user/github/{{ username }}?period=all_time"

--- a/gitbrag/www.py
+++ b/gitbrag/www.py
@@ -388,7 +388,7 @@ async def user_report(
     Args:
         request: FastAPI request object
         username: GitHub username
-        period: Time period (1_year, 2_years, all_time)
+        period: Time period (1_year, 2_years, 3_years, 5_years, all_time)
         force: Force regenerate regardless of cache
         github_client: Optional authenticated GitHub client
         background_tasks: FastAPI background tasks for async generation
@@ -534,8 +534,12 @@ async def user_report(
         else:
             cache_age_str = f"{int(cache_age_seconds / 86400)} days ago"
 
-    # Calculate date range for display
-    since, until = calculate_date_range(period)
+    # Use cached dates if available, otherwise fall back to calculated
+    if cached_meta and "since" in cached_meta and "until" in cached_meta:
+        since = datetime.fromisoformat(cached_meta["since"])
+        until = datetime.fromisoformat(cached_meta["until"])
+    else:
+        since, until = calculate_date_range(period)
 
     # Prepare template context
     context = {

--- a/openspec/changes/archive/2026-05-19-add-3-year-period/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-19-add-3-year-period/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-19

--- a/openspec/changes/archive/2026-05-19-add-3-year-period/design.md
+++ b/openspec/changes/archive/2026-05-19-add-3-year-period/design.md
@@ -1,0 +1,143 @@
+# Design: add-3-year-period
+
+## Context
+
+The report generation pipeline uses a period string that flows from a URL query parameter through normalization, date range calculation, cache keying, background task execution, and template rendering. The existing periods are `1_year` (365d), `2_years` (730d), `5_years` (1825d), and `all_time` (since 2008). The period string is validated in `normalize_period()`, converted to datetimes in `calculate_date_range()`, and displayed in `user_report.html` via Jinja conditionals. No new data models, services, or external dependencies are needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add `3_years` (1095 days) as a valid period option
+- Display "3 Years" in the period selector between "2 Years" and "5 Years"
+- Update home page marketing copy to include 3 years
+- Display the actual cached date range (start → end) instead of recalculating from "now"
+
+**Non-Goals:**
+
+- Adding other time periods (e.g., 6 months, 4 years)
+- Changing the ordering or layout of the period selector beyond inserting the new option
+- Modifying CLI behavior (the CLI uses `--since`/`--until` directly, not period names)
+- Changing the cache metadata format beyond using existing fields
+
+## Decisions
+
+### D1: `3_years` uses 1095 days (3 × 365)
+
+**Decision:** Follow the existing convention of `365 × N` days rather than a calendar-aware calculation. The existing `2_years` uses 730 days and `5_years` uses 1825 days, so `3_years` uses 1095 days for consistency.
+
+```python
+# gitbrag/services/reports.py
+# In calculate_date_range(), add between 2_years and 5_years:
+elif period == "3_years":
+    since = until - timedelta(days=1095)
+```
+
+**Alternative considered:** Calendar-aware subtraction using `dateutil.relativedelta`. Rejected — existing periods use fixed day counts, and maintaining consistency matters more than leap year precision.
+
+### D2: `3_years` sits between `2_years` and `5_years` in the UI
+
+**Decision:** Insert the new link between the 2-year and 5-year options in the period selector, maintaining ascending chronological order.
+
+```html
+<!-- gitbrag/templates/user_report.html -->
+<a href="/user/github/{{ username }}?period=3_years"
+  class="period-link {% if period == '3_years' %}active{% endif %}">3 Years</a>
+```
+
+**Alternative considered:** Placing it at the end. Rejected — ascending order is more intuitive for users scanning options.
+
+### D3: No changes to repository sorting logic
+
+**Decision:** The `all_time` period has special sorting behavior (by PR count instead of star increase). The `3_years` period should use the standard star-increase sorting, same as `1_year` and `2_years`.
+
+**Rationale:** The special `all_time` sorting exists because star accumulation over 15+ years is a better signal than recent star velocity. Three years is close enough to the 1 and 2 year windows that star increase remains the appropriate sort metric.
+
+### D4: Use cached date range for display instead of recalculating from "now"
+
+**Decision:** When serving cached data, use the `since` and `until` values stored in the cache metadata (`cached_meta`) rather than recalculating them from `calculate_date_range()`. The cache metadata is already populated by both `reports.py` and `background_tasks.py` with the actual date range used during generation.
+
+Current behavior in `www.py:538`:
+```python
+# Always recalculates from "now" — shows a moving end date even for stale cached data
+since, until = calculate_date_range(period)
+```
+
+New behavior — use cached metadata when available:
+```python
+# Use cached dates if available, otherwise fall back to calculated
+if cached_meta and "since" in cached_meta and "until" in cached_meta:
+    since = datetime.fromisoformat(cached_meta["since"])
+    until = datetime.fromisoformat(cached_meta["until"])
+else:
+    since, until = calculate_date_range(period)
+```
+
+**Rationale:** The current approach always shows "today" as the end date, even when serving stale cached data from days or weeks ago. This misleads users about what data is actually in the report. The cache metadata already stores the real dates used during generation, so using them is a low-cost fix with no schema changes.
+
+**Alternative considered:** Always pass `since`/`until` in the cached report data itself. Rejected — the metadata key already exists and contains the fields, no schema migration needed.
+
+## Implementation Detail
+
+### `gitbrag/services/reports.py`
+
+Two changes in existing functions:
+
+1. `normalize_period()` — add `"3_years"` to the allowed tuple (line 40)
+2. `calculate_date_range()` — add `elif period == "3_years"` branch with `timedelta(days=1095)` (between lines 62-63)
+
+### `gitbrag/templates/user_report.html`
+
+Two changes:
+
+1. Period description block — add `{% elif period == "3_years" %}Past 3 years` between the 2-year and 5-year branches
+2. Period selector — add the "3 Years" link between the 2-year and 5-year links
+
+### `gitbrag/templates/home.html`
+
+Update the marketing copy line that lists available periods from "1yr, 2yr, 5yr" to "1yr, 2yr, 3yr, 5yr".
+
+### `gitbrag/www.py`
+
+Two changes:
+
+1. Update the docstring for the `period` query parameter to include `3_years`.
+2. Use cached `since`/`until` from `cached_meta` for display instead of recalculating from "now" (replacing line 538's `calculate_date_range(period)` call).
+
+### `gitbrag/services/background_tasks.py`
+
+Update the docstring for the `period` parameter to include `3_years`.
+
+### `docs/dev/web.md`
+
+Update the period filtering documentation to include 3 years.
+
+## Testing Philosophy
+
+### Date range display accuracy
+
+Verify that when serving cached data, the displayed date range matches the actual `since`/`until` stored in cache metadata — not a recalculated range from "now". Test with stale cached data where the end date should be in the past.
+
+### Period normalization
+
+Verify that `3_years` is accepted by `normalize_period()` and returns `"3_years"` unchanged. Confirm that invalid periods still fall back to `1_year`.
+
+### Date range calculation
+
+Verify that `calculate_date_range("3_years")` returns a date range of approximately 1095 days.
+
+### UI rendering
+
+Test that the `3_years` period renders the correct description text ("Past 3 years") and that the "3 Years" link appears in the period selector with the correct `?period=3_years` query parameter.
+
+### End-to-end report generation
+
+Test the full flow with `period=3_years` through the background task to ensure PRs are collected for the correct 3-year date range.
+
+## Risks / Trade-offs
+
+### Period selector crowding
+
+**Risk:** With five options, the period selector flex row may wrap on narrower screens.
+
+**Mitigation:** The existing CSS uses `flex-wrap: wrap` — the extra item should wrap naturally. If needed, the font size or spacing can be adjusted, but this is unlikely to be an issue given the current viewport targets.

--- a/openspec/changes/archive/2026-05-19-add-3-year-period/proposal.md
+++ b/openspec/changes/archive/2026-05-19-add-3-year-period/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The current period selector jumps from 2 years to 5 years, leaving a gap for users who want to see their contributions over a 3-year window — a common timeframe for promotion cycles, contract renewals, and career milestones.
+
+## What Changes
+
+- Add a "3 Years" option to the period selector on the user report page
+- Extend the backend period normalization and date range calculation to support `3_years` (1095 days)
+- Update the displayed date range to use actual cached dates instead of recalculating from "now"
+- Update marketing copy on the home page to include 3 years
+- Fix documentation to include all current periods (3 years, 5 years) and the cached date range behavior
+- Update tests
+
+## Capabilities
+
+### New Capabilities
+
+- `report-periods`: Support for configurable time period ranges in user reports, including the new 3-year option alongside existing 1, 2, and 5-year periods plus all-time
+
+### Modified Capabilities
+
+(none — no existing specs to modify)
+
+## Impact
+
+- `gitbrag/services/reports.py` — period normalization and date range calculation
+- `gitbrag/www.py` — route docstring, cached date range display logic
+- `gitbrag/templates/user_report.html` — period selector UI and description text
+- `gitbrag/templates/home.html` — marketing copy
+- `gitbrag/services/background_tasks.py` — docstring
+- `docs/dev/web.md` — period filtering, query params, report template documentation (also adds missing 5_years)
+- `tests/test_reports.py` — new tests for `normalize_period` and `calculate_date_range`
+- `tests/test_www.py` — new tests for period rendering and cached date range display

--- a/openspec/changes/archive/2026-05-19-add-3-year-period/tasks.md
+++ b/openspec/changes/archive/2026-05-19-add-3-year-period/tasks.md
@@ -1,0 +1,30 @@
+## 1. Backend Period Logic
+
+- [x] 1.1 Add `3_years` to the allowed periods in `normalize_period()` in `gitbrag/services/reports.py`
+- [x] 1.2 Add `3_years` date range branch (1095 days) in `calculate_date_range()` in `gitbrag/services/reports.py`
+- [x] 1.3 Use cached `since`/`until` from `cached_meta` for display in `gitbrag/www.py` (with fallback to `calculate_date_range`)
+- [x] 1.4 Update the `period` parameter docstring in `gitbrag/www.py` (line 391)
+- [x] 1.5 Update the `period` parameter docstring in `gitbrag/services/background_tasks.py` (line 57)
+
+## 2. Template Changes
+
+- [x] 2.1 Add "3 Years" link to the period selector in `gitbrag/templates/user_report.html` (between 2-year and 5-year links)
+- [x] 2.2 Add "Past 3 years" description branch in `gitbrag/templates/user_report.html`
+- [x] 2.3 Update home page marketing copy to include "3yr" in `gitbrag/templates/home.html` (line 80)
+
+## 3. Documentation
+
+- [x] 3.1 Update period filtering in `docs/dev/web.md` (line 10: add 3 and 5 years), query params (line 206: add 3_years, 5_years), and report template section (line 253)
+
+## 4. Tests
+
+- [x] 4.1 Add new test for `normalize_period("3_years")` in `tests/test_reports.py`
+- [x] 4.2 Add new test for `calculate_date_range("3_years")` in `tests/test_reports.py`
+- [x] 4.3 Add test for `3_years` period rendering (selector link and description text) in `tests/test_www.py`
+- [x] 4.4 Add test for cached date range display using `cached_meta` in `tests/test_www.py`
+- [x] 4.5 Add test for date range fallback when `cached_meta` is missing in `tests/test_www.py`
+
+## 5. Verification
+
+- [x] 5.1 Run `make tests` to ensure all tests pass
+- [x] 5.2 Run `make chores` to ensure formatting is correct

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/openspec/specs/report-periods/spec.md
+++ b/openspec/specs/report-periods/spec.md
@@ -1,0 +1,58 @@
+## Purpose
+
+Define the supported time periods for contribution reports and how they are normalized, calculated, and displayed.
+
+## Requirements
+
+### Requirement: Three-year period is accepted and normalized
+The system SHALL accept `3_years` as a valid period string in `normalize_period()` and return it unchanged.
+
+#### Scenario: Valid three-year period normalization
+- **WHEN** `normalize_period("3_years")` is called
+- **THEN** the result is `"3_years"`
+
+### Requirement: Three-year date range calculation
+The system SHALL calculate a 1095-day date range for the `3_years` period in `calculate_date_range()`.
+
+#### Scenario: Three-year date range
+- **WHEN** `calculate_date_range("3_years")` is called
+- **THEN** the returned `since` datetime is 1095 days before the current UTC time
+
+### Requirement: Cached date range is displayed accurately
+When serving a cached report, the displayed date range SHALL reflect the actual `since` and `until` dates stored in cache metadata, not a recalculated range from "now".
+
+#### Scenario: Stale cached report shows original dates
+- **WHEN** a report is served from cache with `cached_meta` containing `since` and `until` fields
+- **THEN** the displayed `since_date` and `until_date` match those cached values formatted as `%Y-%m-%d`
+
+#### Scenario: Missing cache metadata falls back to calculated range
+- **WHEN** a report is served but `cached_meta` is missing or lacks `since`/`until` fields
+- **THEN** the displayed date range is calculated from `calculate_date_range(period)`
+
+### Requirement: Three-year period appears in the period selector
+The user report page SHALL display a "3 Years" link in the period selector between the "2 Years" and "5 Years" options.
+
+#### Scenario: Three-year link in selector
+- **WHEN** a user views a report at `/user/github/{username}`
+- **THEN** the period selector contains a link with text "3 Years" and href `/user/github/{username}?period=3_years`
+
+### Requirement: Three-year active state in selector
+The "3 Years" link SHALL have the `active` class when the current period is `3_years`.
+
+#### Scenario: Active three-year link
+- **WHEN** a user views a report with `?period=3_years`
+- **THEN** the "3 Years" link has the `active` CSS class
+
+### Requirement: Three-year period description text
+The period description SHALL display "Past 3 years" when the period is `3_years`.
+
+#### Scenario: Three-year description
+- **WHEN** a user views a report with `?period=3_years`
+- **THEN** the period description reads "Past 3 years"
+
+### Requirement: Home page mentions three-year period
+The home page SHALL include "3yr" in its period options marketing copy.
+
+#### Scenario: Home page period listing
+- **WHEN** a user views the home page
+- **THEN** the period options text includes "3yr" alongside "1yr", "2yr", "5yr", and "all time"

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,6 +1,8 @@
 """Tests for report generation services."""
 
-from gitbrag.services.reports import generate_cache_key
+from datetime import timedelta
+
+from gitbrag.services.reports import calculate_date_range, generate_cache_key, normalize_period
 
 
 def test_generate_cache_key_normalizes_username():
@@ -54,3 +56,24 @@ def test_generate_cache_key_with_star_increase():
 
     # But keys should differ based on parameter
     assert key_without_stars != key_with_stars
+
+
+def test_normalize_period_returns_3_years():
+    """Test that 3_years is accepted as a valid period."""
+    assert normalize_period("3_years") == "3_years"
+    assert normalize_period("3_Years") == "3_years"
+    assert normalize_period("  3_years  ") == "3_years"
+
+
+def test_normalize_period_fallback():
+    """Test that invalid periods fall back to 1_year."""
+    assert normalize_period("invalid") == "1_year"
+    assert normalize_period(None) == "1_year"
+    assert normalize_period("") == "1_year"
+
+
+def test_calculate_date_range_3_years():
+    """Test that 3_years produces a 1095-day range."""
+    since, until = calculate_date_range("3_years")
+    diff = until - since
+    assert diff == timedelta(days=1095)

--- a/tests/test_www.py
+++ b/tests/test_www.py
@@ -197,3 +197,60 @@ def test_company_name_with_at_symbol_becomes_link():
     assert "user_profile.company.startswith('@')" in content
     assert 'href="https://github.com/{{ user_profile.company[1:]' in content
     assert 'target="_blank"' in content
+
+
+def test_3_years_period_in_template():
+    """Test that the 3_years period renders correctly in the template."""
+    import os
+
+    template_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "gitbrag", "templates", "user_report.html")
+    with open(template_path) as f:
+        content = f.read()
+
+    # Check period selector has 3 Years link
+    assert "period=3_years" in content
+    assert ">3 Years</a>" in content
+
+    # Check period description has 3_years branch
+    assert 'period == "3_years"' in content
+    assert "Past 3 years" in content
+
+
+def test_cached_date_range_uses_cached_meta():
+    """Test that cached_meta since/until are used for date display when available."""
+    import os
+
+    www_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "gitbrag", "www.py")
+    with open(www_path) as f:
+        content = f.read()
+
+    # Verify the code uses cached_meta for date range
+    assert 'cached_meta and "since" in cached_meta and "until" in cached_meta' in content
+    assert 'datetime.fromisoformat(cached_meta["since"])' in content
+    assert 'datetime.fromisoformat(cached_meta["until"])' in content
+
+
+def test_date_range_fallback_when_no_cached_meta():
+    """Test that calculate_date_range is used as fallback when cached_meta is missing."""
+    import os
+
+    www_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "gitbrag", "www.py")
+    with open(www_path) as f:
+        content = f.read()
+
+    # Verify fallback to calculate_date_range exists
+    assert "calculate_date_range(period)" in content
+
+    # Verify the fallback is in an else block after the cached_meta check
+    lines = content.split("\n")
+    cached_meta_idx = None
+    fallback_idx = None
+    for i, line in enumerate(lines):
+        if 'cached_meta and "since" in cached_meta' in line:
+            cached_meta_idx = i
+        if "calculate_date_range(period)" in line:
+            fallback_idx = i
+
+    assert cached_meta_idx is not None, "Should have cached_meta check"
+    assert fallback_idx is not None, "Should have calculate_date_range fallback"
+    assert fallback_idx > cached_meta_idx, "Fallback should come after cached_meta check"


### PR DESCRIPTION
- Add 3_years to normalize_period() and calculate_date_range() (1095 days)
- Use cached_meta since/until for accurate date display in cached reports
- Add 3 Years link to period selector in user report template
- Update home page marketing copy and documentation
- Add tests for new period and cached date range fallback
- Fix dev port mapping from 80 to 8080
